### PR TITLE
Add 'data' field to ExtType

### DIFF
--- a/msgpack-stubs/ext.pyi
+++ b/msgpack-stubs/ext.pyi
@@ -4,7 +4,7 @@ import datetime
 
 class _ExtType(NamedTuple):
     code: int
-    code: bytes
+    data: bytes
 
 class ExtType(_ExtType): ...
 


### PR DESCRIPTION
From the look of it, it seems like it's just a copy/paste error. Definition of ExtType here: https://github.com/msgpack/msgpack-python/blob/38dba9634e4efa7886a777b9e7c739dc148da457/msgpack/ext.py#L21